### PR TITLE
dth/remove adjustment invalid operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,49 @@ pkg
 *.swp
 spec/dummy
 spec/avalara_config.yml
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -30,14 +30,14 @@ Spree::TaxRate.class_eval do
     end
   end
 
-  def adjust(order, item)
+  def adjust(order, items)
     # We've overridden the class-level TaxRate.adjust so nothing should be calling this code
     raise SpreeAvatax::TaxRateInvalidOperation.new("Spree::TaxRate#adjust should never be called when Avatax is present")
   end
 
   def compute_amount(item)
-    # Avatax tax adjustments should always be in a closed state so Spree should never attempt to call this code
-    raise SpreeAvatax::TaxRateInvalidOperation.new("Spree::TaxRate#compute_amount should never be called when Avatax is present")
+    #This method was changed to no-op instead of raising an error.  This method is called by the admin interface
+    #when a user can manually unlock all adjustments and edit them.  When unlocked this method will be called during an update.
   end
 
   private


### PR DESCRIPTION
The admin interface allows the user to unlock adjustments.   When the adjustments are saves they are updated if they are in an unlocked state.

The alternative is to update the Adjustment decorator to not touch tax rates inside of Adjustment#update
https://gist.github.com/dhonig/97dff96ea26791fb20ce

This is a simpler change and logically there is no difference.